### PR TITLE
Codespell to fix typos

### DIFF
--- a/modal.lua
+++ b/modal.lua
@@ -1080,7 +1080,7 @@ do
    --- Add an OSC handler.
    -- @param pattern The pattern to match on.
    -- @param func The callback to run if a message is received.
-   -- The callback will get a single argument `data` from where the messsage can be retrived.
+   -- The callback will get a single argument `data` from where the message can be retrieved.
    -- @usage
    -- osc:add_handler('/pattern', function(data)
    --   -- message table, can be converted to Message if needed.
@@ -1649,7 +1649,7 @@ do
       return concat(b, a)
    end
    
-   ---pipe fuctions: pipe(f, g, h)(x) -> f(g(h(x)))
+   ---pipe functions: pipe(f, g, h)(x) -> f(g(h(x)))
    ---@param fs (fun(x : any) : any)[]
    ---@return any
    function ut.pipe(fs)
@@ -2528,7 +2528,7 @@ do
    
    -- TODO: check AST
    
-   -- Instanciate a new AST->source synthetizer
+   -- Instantiate a new AST->source synthesizer
    function a2s.new()
       local self = {
          _acc = {}, -- Accumulates pieces of source as strings
@@ -2539,9 +2539,9 @@ do
    end
    
    --------------------------------------------------------------------------------
-   -- Run a synthetizer on the `ast' arg and return the source as a string.
+   -- Run a synthesizer on the `ast' arg and return the source as a string.
    -- Can also be used as a static method `M.run (ast)'; in this case,
-   -- a temporary Metizer is instanciated on the fly.
+   -- a temporary Metizer is instantiated on the fly.
    --------------------------------------------------------------------------------
    function a2s:run(ast)
       if not ast then
@@ -2553,7 +2553,7 @@ do
    end
    
    --------------------------------------------------------------------------------
-   -- Accumulate a piece of source file in the synthetizer.
+   -- Accumulate a piece of source file in the synthesizer.
    --------------------------------------------------------------------------------
    function a2s:acc(x)
       if x then
@@ -2690,7 +2690,7 @@ do
       unm = "-",
    }
    -- Accumulate the source representation of AST `node' in
-   -- the synthetizer. Most of the work is done by delegating to
+   -- the synthesizer. Most of the work is done by delegating to
    -- the method having the name of the AST tag.
    -- If something can't be converted to normal sources, it's
    -- instead dumped as a `-{ ... }' splice in the source accumulator.
@@ -2717,7 +2717,7 @@ do
    -- `sep' is an optional separator to be accumulated between each list element,
    -- it can be a string or a synth method.
    -- `start' is an optional number (default == 1), indicating which is the
-   -- first element of list to be converted, so that we can skip the begining
+   -- first element of list to be converted, so that we can skip the beginning
    -- of a list.
    --------------------------------------------------------------------------------
    function a2s:list(list, sep, start)
@@ -3574,7 +3574,7 @@ do
             if not ok then
                return false
             end
-            local lua_src = a2s.run(ast) -- TODO: imporve api
+            local lua_src = a2s.run(ast) -- TODO: improve api
             return lua_src
          end
    
@@ -6215,7 +6215,7 @@ do
       local listen = function()
          l, e = c:receive()
          if not e then
-            print("recieved: ", l)
+            print("received: ", l)
             eval(l)
          end
       end

--- a/scripts/pack.lua
+++ b/scripts/pack.lua
@@ -110,4 +110,4 @@ header = header .. "\n" .. "return modal"
 print(header)
 
 -- TODO: lfs
--- TODO: stylua the result if avaliable
+-- TODO: stylua the result if available

--- a/spec/pattern_spec.lua
+++ b/spec/pattern_spec.lua
@@ -408,7 +408,7 @@ describe("slow", function()
 end)
 
 describe("early", function()
-   it("should return a pattern whose Events moved backword in time", function()
+   it("should return a pattern whose Events moved backward in time", function()
       local pat = early(0.5, reify { "bd", "sd" })
       local expected = reify { "sd", "bd" }
       assert.equal(expected, pat)
@@ -481,7 +481,7 @@ describe("run", function()
 end)
 
 describe("euclid", function()
-   it("shoudl gen euclid pats", function()
+   it("should gen euclid pats", function()
       local pat = euclidRot(3, 8, 1, "bd")
       local expected = struct(bjork(3, 8, 1), "bd")
       assert.equal(expected, pat)

--- a/spec/util_spec.lua
+++ b/spec/util_spec.lua
@@ -74,7 +74,7 @@ end)
 -- end)
 
 describe("auto curry", function()
-   it("shoudl do felixable curry", function()
+   it("should do felixable curry", function()
       assert.same(pat.fast(2, 1)(0, 1), pat.fast(2)(1)(0, 1))
       assert.same(pat.fast(2, 1)(0, 1), pat.fast(2)(1)(0, 1))
    end)

--- a/spec/valuemap_spec.lua
+++ b/spec/valuemap_spec.lua
@@ -32,7 +32,7 @@ describe("control", function()
 end)
 
 -- describe("note", function()
---    it("shoudl parse chords", function()
+--    it("should parse chords", function()
 --       ---TODO:
 --       assert.pat(stack { n(0), n(4), n(7) }, note "c'maj")
 --    end)

--- a/src/a2s.lua
+++ b/src/a2s.lua
@@ -9,7 +9,7 @@ local unpack = unpack or rawget(table, "unpack")
 
 -- TODO: check AST
 
--- Instanciate a new AST->source synthetizer
+-- Instantiate a new AST->source synthesizer
 function a2s.new()
    local self = {
       _acc = {}, -- Accumulates pieces of source as strings
@@ -20,9 +20,9 @@ function a2s.new()
 end
 
 --------------------------------------------------------------------------------
--- Run a synthetizer on the `ast' arg and return the source as a string.
+-- Run a synthesizer on the `ast' arg and return the source as a string.
 -- Can also be used as a static method `M.run (ast)'; in this case,
--- a temporary Metizer is instanciated on the fly.
+-- a temporary Metizer is instantiated on the fly.
 --------------------------------------------------------------------------------
 function a2s:run(ast)
    if not ast then
@@ -34,7 +34,7 @@ function a2s:run(ast)
 end
 
 --------------------------------------------------------------------------------
--- Accumulate a piece of source file in the synthetizer.
+-- Accumulate a piece of source file in the synthesizer.
 --------------------------------------------------------------------------------
 function a2s:acc(x)
    if x then
@@ -171,7 +171,7 @@ local op_symbol = {
    unm = "-",
 }
 -- Accumulate the source representation of AST `node' in
--- the synthetizer. Most of the work is done by delegating to
+-- the synthesizer. Most of the work is done by delegating to
 -- the method having the name of the AST tag.
 -- If something can't be converted to normal sources, it's
 -- instead dumped as a `-{ ... }' splice in the source accumulator.
@@ -198,7 +198,7 @@ end
 -- `sep' is an optional separator to be accumulated between each list element,
 -- it can be a string or a synth method.
 -- `start' is an optional number (default == 1), indicating which is the
--- first element of list to be converted, so that we can skip the begining
+-- first element of list to be converted, so that we can skip the beginning
 -- of a list.
 --------------------------------------------------------------------------------
 function a2s:list(list, sep, start)

--- a/src/losc.lua
+++ b/src/losc.lua
@@ -1062,7 +1062,7 @@ end
 --- Add an OSC handler.
 -- @param pattern The pattern to match on.
 -- @param func The callback to run if a message is received.
--- The callback will get a single argument `data` from where the messsage can be retrived.
+-- The callback will get a single argument `data` from where the message can be retrieved.
 -- @usage
 -- osc:add_handler('/pattern', function(data)
 --   -- message table, can be converted to Message if needed.

--- a/src/lulpeg.lua
+++ b/src/lulpeg.lua
@@ -28,7 +28,7 @@ end
 --=============================================================================
 do
    local _ENV = _ENV
-   packages["analizer"] = function(...)
+   packages["analyzer"] = function(...)
       local u = require "util"
       local nop, weakkey = u.nop, u.weakkey
       local hasVcache, hasCmtcache, lengthcache = weakkey {}, weakkey {}, weakkey {}

--- a/src/notation.lua
+++ b/src/notation.lua
@@ -436,7 +436,7 @@ local function make_gen(top_level)
          if not ok then
             return false
          end
-         local lua_src = a2s.run(ast) -- TODO: imporve api
+         local lua_src = a2s.run(ast) -- TODO: improve api
          return lua_src
       end
 

--- a/src/server.lua
+++ b/src/server.lua
@@ -37,7 +37,7 @@ local function server()
    local listen = function()
       l, e = c:receive()
       if not e then
-         print("recieved: ", l)
+         print("received: ", l)
          eval(l)
       end
    end

--- a/src/ut.lua
+++ b/src/ut.lua
@@ -501,7 +501,7 @@ function ut.rotate(step, list)
    return concat(b, a)
 end
 
----pipe fuctions: pipe(f, g, h)(x) -> f(g(h(x)))
+---pipe functions: pipe(f, g, h)(x) -> f(g(h(x)))
 ---@param fs (fun(x : any) : any)[]
 ---@return any
 function ut.pipe(fs)


### PR DESCRIPTION
@neo451 this introduces some minor typo fixes to the code itself, mostly in comments.